### PR TITLE
start under xfce only

### DIFF
--- a/data/xfdashboard-autostart.desktop.in.in
+++ b/data/xfdashboard-autostart.desktop.in.in
@@ -5,6 +5,6 @@ _Comment=Start xfdashboard as daemon in background
 TryExec=@bindir@/xfdashboard
 Exec=@bindir@/xfdashboard -d
 Icon=xfdashboard
-NotShowIn=GNOME;KDE;Unity;
+OnlyShowIn=XFCE;
 Terminal=false
 Hidden=true

--- a/data/xfdashboard.desktop.in.in
+++ b/data/xfdashboard.desktop.in.in
@@ -7,5 +7,5 @@ TryExec=@bindir@/xfdashboard
 Exec=@bindir@/xfdashboard
 Icon=xfdashboard
 Categories=System;
-NotShowIn=GNOME;KDE;Unity;
+OnlyShowIn=XFCE;
 Terminal=false


### PR DESCRIPTION
with current NotShowIn=GNOME;KDE;Unity; xfdesktop starts in mate session also, and displayed in mate-menu.