### PR TITLE
Fix debian apt-get library name for glib2

### DIFF
--- a/README
+++ b/README
@@ -31,7 +31,7 @@ libXinerama (for multi-monitor support)
 
 On debian based distros, all requeriments are installed with:
 
-> apt-get install xfce4-dev-tools build-essential glib2 libglib2.0-dev xorg-dev libwnck-3-dev libclutter-1.0-dev libgarcon-1-0-dev libxfconf-0-dev libxfce4util-dev libxfce4ui-2-dev libxcomposite-dev libxdamage-dev libxinerama-dev
+> apt-get install xfce4-dev-tools build-essential glib2.0 libglib2.0-dev xorg-dev libwnck-3-dev libclutter-1.0-dev libgarcon-1-0-dev libxfconf-0-dev libxfce4util-dev libxfce4ui-2-dev libxcomposite-dev libxdamage-dev libxinerama-dev
 
 Homepage
 ========


### PR DESCRIPTION
Installing "glib2" with apt-get will fail because it's "glib2.0" in debian

See: https://packages.debian.org/de/source/stretch/glib2.0

installing glib2 will fail: 

``` sudo apt-get install glib2
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package glib2
``` 