### PR TITLE
Improve check dependencies

### DIFF
--- a/configure.ac.in
+++ b/configure.ac.in
@@ -22,7 +22,6 @@ m4_define([clutter_minimum_version], [1.12.0])
 m4_define([glib_minimum_version], [2.32])
 m4_define([gio_minimum_version], [2.32])
 m4_define([garcon_minimum_version], [0.2.0])
-m4_define([xfconf_minimum_version], [4.13.0])
 m4_define([xcomposite_minimum_version], [0.2])
 m4_define([intltool_minimum_version], [0.35])
 m4_define([gtk_minimum_version], [3.2])
@@ -199,10 +198,12 @@ AC_SUBST(HAVE_XINERAMA)
 dnl ***********************************
 dnl *** Check for required packages ***
 dnl ***********************************
-XDT_CHECK_PACKAGE([LIBWNCK], [libwnck-3.0], [wnck_minimum_version])
-XDT_CHECK_PACKAGE([CLUTTER_COGL], [clutter-cogl-1.0], [clutter_minimum_version])
-XDT_CHECK_PACKAGE([GTK], [gtk+-3.0], [gtk_minimum_version])
+XDT_CHECK_PACKAGE([LIBWNCK], [libwnck-3.0], [wnck_minimum_version], [XFDASHBOARD_REQUIRES="$XFDASHBOARD_REQUIRES libwnck-3.0"])
+XDT_CHECK_PACKAGE([CLUTTER_COGL], [clutter-cogl-1.0], [clutter_minimum_version], [XFDASHBOARD_REQUIRES="$XFDASHBOARD_REQUIRES clutter-cogl-1.0"])
+XDT_CHECK_PACKAGE([GTK], [gtk+-3.0], [gtk_minimum_version], [XFDASHBOARD_REQUIRES="$XFDASHBOARD_REQUIRES gtk+-3.0"])
 XDT_CHECK_PACKAGE([GLIB], [glib-2.0], [glib_minimum_version], [
+	XFDASHBOARD_REQUIRES="$XFDASHBOARD_REQUIRES glib-2.0"
+
 	XDT_PROG_PKG_CONFIG()
 
 	GLIB_MKENUMS=`$PKG_CONFIG --variable=glib_mkenums glib-2.0`
@@ -210,21 +211,37 @@ XDT_CHECK_PACKAGE([GLIB], [glib-2.0], [glib_minimum_version], [
 
 	GLIB_GENMARSHAL=`$PKG_CONFIG --variable=glib_genmarshal glib-2.0`
 	AC_SUBST(GLIB_GENMARSHAL)])
-XDT_CHECK_PACKAGE([GIO], [gio-2.0], [gio_minimum_version])
-XDT_CHECK_PACKAGE([GIO_UNIX], [gio-unix-2.0], [gio_minimum_version])
-XDT_CHECK_PACKAGE([GARCON], [garcon-1], [garcon_minimum_version])
-XDT_CHECK_PACKAGE([LIBXFCONF], [libxfconf-0], [xfconf_minimum_version])
-XDT_CHECK_PACKAGE([LIBXFCE4UTIL], [libxfce4util-1.0],[libxfce4util_minimum_version])
-XDT_CHECK_PACKAGE([LIBXFCE4UI], [libxfce4ui-2],[libxfce4ui_minimum_version])
+XDT_CHECK_PACKAGE([GIO], [gio-2.0], [gio_minimum_version], [XFDASHBOARD_REQUIRES="$XFDASHBOARD_REQUIRES gio-2.0"])
+XDT_CHECK_PACKAGE([GIO_UNIX], [gio-unix-2.0], [gio_minimum_version], [XFDASHBOARD_REQUIRES="$XFDASHBOARD_REQUIRES gio-unix-2.0"])
+XDT_CHECK_PACKAGE([GARCON], [garcon-1], [garcon_minimum_version], [XFDASHBOARD_REQUIRES="$XFDASHBOARD_REQUIRES garcon-1"])
+XDT_CHECK_PACKAGE([LIBXFCONF], [libxfconf-0], [4.13.0], [
+	XFDASHBOARD_REQUIRES="$XFDASHBOARD_REQUIRES libxfconf-0"], [
+	XDT_CHECK_PACKAGE([LIBXFCONF], [libxfconf-0], [4.12.0], [
+                XFDASHBOARD_REQUIRES="$XFDASHBOARD_REQUIRES libxfconf-0"
+
+                XDT_CHECK_PACKAGE([DBUS_GLIB], [dbus-glib-1], [0.98], [
+			ac_dbus_glib=yes
+			XFDASHBOARD_REQUIRES="$XFDASHBOARD_REQUIRES dbus-glib-1"], [
+			ac_dbus_glib=no])
+                AC_DEFINE([XFCONF_LEGACY], [], [Use xfconf < 4.13 to obtain array type])
+	])
+])
+XDT_CHECK_PACKAGE([LIBXFCE4UTIL], [libxfce4util-1.0],[libxfce4util_minimum_version], [XFDASHBOARD_REQUIRES="$XFDASHBOARD_REQUIRES libxfce4util-1.0"])
+XDT_CHECK_PACKAGE([LIBXFCE4UI], [libxfce4ui-2],[libxfce4ui_minimum_version], [XFDASHBOARD_REQUIRES="$XFDASHBOARD_REQUIRES libxfce4ui-2"])
+AM_CONDITIONAL([DBUS_GLIB], [test x"$ac_dbus_glib" = x"yes"])
 
 dnl **********************************************
 dnl *** Check for Clutter and its backend: GDK ***
 dnl **********************************************
 XDT_CHECK_PACKAGE([CLUTTER], [clutter-1.0], [clutter_minimum_version], [
+	XFDASHBOARD_REQUIRES="$XFDASHBOARD_REQUIRES clutter-1.0"
+
 	XDT_CHECK_PACKAGE([CLUTTER_GDK], [clutter-gdk-1.0], [clutter_minimum_version],
 	[ac_clutter_gdk=yes], [ac_clutter_gdk=no])]
 )
 AM_CONDITIONAL([GDK], [test x"$ac_clutter_gdk" = x"yes"])
+
+AC_SUBST(XFDASHBOARD_REQUIRES)
 
 dnl ***********************************
 dnl *** Check for debugging support ***
@@ -333,6 +350,9 @@ echo "  garcon:           $GARCON_VERSION"
 echo "  libxconf:         $LIBXFCONF_VERSION"
 echo "  libxfce4ui:       $LIBXFCE4UI_VERSION"
 echo "  libxfce4util:     $LIBXFCE4UTIL_VERSION"
+if test "x$ac_dbus_glib" = "xyes" ; then
+echo "  dbus-glib:        $DBUS_GLIB_VERSION"
+fi
 echo
 echo "Tools used:"
 echo "  glib-genmarshal:  $GLIB_GENMARSHAL"

--- a/configure.ac.in
+++ b/configure.ac.in
@@ -22,8 +22,7 @@ m4_define([clutter_minimum_version], [1.12.0])
 m4_define([glib_minimum_version], [2.32])
 m4_define([gio_minimum_version], [2.32])
 m4_define([garcon_minimum_version], [0.2.0])
-m4_define([xfconf_minimum_version], [4.10.0])
-m4_define([dbus_glib_minimum_version], [0.98])
+m4_define([xfconf_minimum_version], [4.13.0])
 m4_define([xcomposite_minimum_version], [0.2])
 m4_define([intltool_minimum_version], [0.35])
 m4_define([gtk_minimum_version], [3.2])
@@ -203,14 +202,7 @@ dnl ***********************************
 XDT_CHECK_PACKAGE([LIBWNCK], [libwnck-3.0], [wnck_minimum_version])
 XDT_CHECK_PACKAGE([CLUTTER_COGL], [clutter-cogl-1.0], [clutter_minimum_version])
 XDT_CHECK_PACKAGE([GTK], [gtk+-3.0], [gtk_minimum_version])
-XDT_CHECK_PACKAGE([GLIB], [glib-2.0], [glib_minimum_version])
-XDT_CHECK_PACKAGE([GIO], [gio-2.0], [gio_minimum_version])
-XDT_CHECK_PACKAGE([GIO_UNIX], [gio-unix-2.0], [gio_minimum_version])
-XDT_CHECK_PACKAGE([GARCON], [garcon-1], [garcon_minimum_version])
-XDT_CHECK_PACKAGE([LIBXFCONF], [libxfconf-0], [xfconf_minimum_version])
-XDT_CHECK_PACKAGE([LIBXFCE4UTIL], [libxfce4util-1.0],[libxfce4util_minimum_version])
-XDT_CHECK_PACKAGE([LIBXFCE4UI], [libxfce4ui-2],[libxfce4ui_minimum_version])
-XDT_CHECK_PACKAGE([DBUS_GLIB], [dbus-glib-1], [dbus_glib_minimum_version], [
+XDT_CHECK_PACKAGE([GLIB], [glib-2.0], [glib_minimum_version], [
 	XDT_PROG_PKG_CONFIG()
 
 	GLIB_MKENUMS=`$PKG_CONFIG --variable=glib_mkenums glib-2.0`
@@ -218,6 +210,12 @@ XDT_CHECK_PACKAGE([DBUS_GLIB], [dbus-glib-1], [dbus_glib_minimum_version], [
 
 	GLIB_GENMARSHAL=`$PKG_CONFIG --variable=glib_genmarshal glib-2.0`
 	AC_SUBST(GLIB_GENMARSHAL)])
+XDT_CHECK_PACKAGE([GIO], [gio-2.0], [gio_minimum_version])
+XDT_CHECK_PACKAGE([GIO_UNIX], [gio-unix-2.0], [gio_minimum_version])
+XDT_CHECK_PACKAGE([GARCON], [garcon-1], [garcon_minimum_version])
+XDT_CHECK_PACKAGE([LIBXFCONF], [libxfconf-0], [xfconf_minimum_version])
+XDT_CHECK_PACKAGE([LIBXFCE4UTIL], [libxfce4util-1.0],[libxfce4util_minimum_version])
+XDT_CHECK_PACKAGE([LIBXFCE4UI], [libxfce4ui-2],[libxfce4ui_minimum_version])
 
 dnl **********************************************
 dnl *** Check for Clutter and its backend: GDK ***
@@ -335,7 +333,6 @@ echo "  garcon:           $GARCON_VERSION"
 echo "  libxconf:         $LIBXFCONF_VERSION"
 echo "  libxfce4ui:       $LIBXFCE4UI_VERSION"
 echo "  libxfce4util:     $LIBXFCE4UTIL_VERSION"
-echo "  dbus-glib:        $DBUS_GLIB_VERSION"
 echo
 echo "Tools used:"
 echo "  glib-genmarshal:  $GLIB_GENMARSHAL"
@@ -345,4 +342,9 @@ echo "Features enabled:"
 echo "  XComposite:       $enabled_x11_extension_composite"
 echo "  XDamage:          $enabled_x11_extension_damage"
 echo "  Xinerama:         $enabled_x11_extension_xinerama"
+if test "x$ac_clutter_gdk" = "xyes" ; then
+echo "  GDK backend:      yes"
+else
+echo "  GDK backend:      no"
+fi
 echo

--- a/configure.ac.in
+++ b/configure.ac.in
@@ -201,7 +201,6 @@ dnl ***********************************
 dnl *** Check for required packages ***
 dnl ***********************************
 XDT_CHECK_PACKAGE([LIBWNCK], [libwnck-3.0], [wnck_minimum_version])
-XDT_CHECK_PACKAGE([CLUTTER], [clutter-1.0], [clutter_minimum_version])
 XDT_CHECK_PACKAGE([CLUTTER_COGL], [clutter-cogl-1.0], [clutter_minimum_version])
 XDT_CHECK_PACKAGE([GTK], [gtk+-3.0], [gtk_minimum_version])
 XDT_CHECK_PACKAGE([GLIB], [glib-2.0], [glib_minimum_version])
@@ -219,6 +218,15 @@ XDT_CHECK_PACKAGE([DBUS_GLIB], [dbus-glib-1], [dbus_glib_minimum_version], [
 
 	GLIB_GENMARSHAL=`$PKG_CONFIG --variable=glib_genmarshal glib-2.0`
 	AC_SUBST(GLIB_GENMARSHAL)])
+
+dnl **********************************************
+dnl *** Check for Clutter and its backend: GDK ***
+dnl **********************************************
+XDT_CHECK_PACKAGE([CLUTTER], [clutter-1.0], [clutter_minimum_version], [
+	XDT_CHECK_PACKAGE([CLUTTER_GDK], [clutter-gdk-1.0], [clutter_minimum_version],
+	[ac_clutter_gdk=yes], [ac_clutter_gdk=no])]
+)
+AM_CONDITIONAL([GDK], [test x"$ac_clutter_gdk" = x"yes"])
 
 dnl ***********************************
 dnl *** Check for debugging support ***

--- a/libxfdashboard/Makefile.am
+++ b/libxfdashboard/Makefile.am
@@ -184,7 +184,6 @@ libxfdashboard_la_CFLAGS = \
 	$(LIBXFCONF_CFLAGS) \
 	$(LIBXFCE4UTIL_CFLAGS) \
 	$(LIBXFCE4UI_CFLAGS) \
-	$(DBUS_GLIB_CFLAGS) \
 	$(PLATFORM_CFLAGS)
 
 libxfdashboard_la_LIBADD = \
@@ -198,7 +197,6 @@ libxfdashboard_la_LIBADD = \
 	$(LIBXFCONF_LIBS) \
 	$(LIBXFCE4UTIL_LIBS) \
 	$(LIBXFCE4UI_LIBS) \
-	$(DBUS_GLIB_LIBS) \
 	$(LIBM)
 
 libxfdashboard_la_LDFLAGS = \

--- a/libxfdashboard/Makefile.am
+++ b/libxfdashboard/Makefile.am
@@ -253,11 +253,20 @@ endif
 gdk_headers = \
 	gdk/window-tracker-backend-gdk.h
 
+libxfdashboard_la_headers += $(gdk_headers)
+
+if GDK
 gdk_sources = \
 	gdk/window-tracker-backend-gdk.c
 
-libxfdashboard_la_headers += $(gdk_headers)
 libxfdashboard_la_SOURCES += $(gdk_sources)
+
+libxfdashboard_la_CFLAGS += \
+	$(CLUTTER_GDK_CFLAGS)
+
+libxfdashboard_la_LIBADD += \
+	$(CLUTTER_GDK_LIBS)
+endif
 
 libxfdashboard_la_includedir = \
 	$(includedir)/xfdashboard/libxfdashboard

--- a/libxfdashboard/Makefile.am
+++ b/libxfdashboard/Makefile.am
@@ -199,6 +199,14 @@ libxfdashboard_la_LIBADD = \
 	$(LIBXFCE4UI_LIBS) \
 	$(LIBM)
 
+if DBUS_GLIB
+libxfdashboard_la_CFLAGS += \
+	$(DBUS_GLIB_CFLAGS)
+
+libxfdashboard_la_LIBADD += \
+	$(DBUS_GLIB_LIBS)
+endif
+
 libxfdashboard_la_LDFLAGS = \
 	-export-dynamic \
 	-version-info $(LIBXFDASHBOARD_VERINFO) \

--- a/libxfdashboard/libxfdashboard.pc.in
+++ b/libxfdashboard/libxfdashboard.pc.in
@@ -5,7 +5,7 @@ includedir=@includedir@
 
 Name: @PACKAGE_TARNAME@
 Description: Library for xfdashboard
-Requires: libwnck-3.0 clutter-1.0 clutter-cogl-1.0 gtk+-3.0 glib-2.0 gio-2.0 gio-unix-2.0 garcon-1 libxfconf-0 libxfce4util-1.0 libxfce4ui-2
+Requires: @XFDASHBOARD_REQUIRES@
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} -lxfdashboard
 Cflags: -I${includedir}/xfdashboard

--- a/libxfdashboard/libxfdashboard.pc.in
+++ b/libxfdashboard/libxfdashboard.pc.in
@@ -5,7 +5,7 @@ includedir=@includedir@
 
 Name: @PACKAGE_TARNAME@
 Description: Library for xfdashboard
-Requires: libwnck-3.0 clutter-1.0 clutter-cogl-1.0 gtk+-3.0 glib-2.0 gio-2.0 gio-unix-2.0 garcon-1 libxfconf-0 libxfce4util-1.0 libxfce4ui-2 dbus-glib-1
+Requires: libwnck-3.0 clutter-1.0 clutter-cogl-1.0 gtk+-3.0 glib-2.0 gio-2.0 gio-unix-2.0 garcon-1 libxfconf-0 libxfce4util-1.0 libxfce4ui-2
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} -lxfdashboard
 Cflags: -I${includedir}/xfdashboard

--- a/libxfdashboard/utils.c
+++ b/libxfdashboard/utils.c
@@ -39,7 +39,6 @@
 #include <glib/gi18n-lib.h>
 #include <clutter/clutter.h>
 #include <gtk/gtk.h>
-#include <dbus/dbus-glib.h>
 #include <gio/gdesktopappinfo.h>
 
 #include <libxfdashboard/stage.h>
@@ -58,7 +57,7 @@ GType xfdashboard_pointer_array_get_type(void)
 
 	if(g_once_init_enter(&type__volatile))
 	{
-		type=dbus_g_type_get_collection("GPtrArray", G_TYPE_VALUE);
+		type=G_TYPE_PTR_ARRAY;
 		g_once_init_leave(&type__volatile, type);
 	}
 

--- a/libxfdashboard/utils.c
+++ b/libxfdashboard/utils.c
@@ -39,6 +39,9 @@
 #include <glib/gi18n-lib.h>
 #include <clutter/clutter.h>
 #include <gtk/gtk.h>
+#ifdef XFCONF_LEGACY
+#include <dbus/dbus-glib.h>
+#endif
 #include <gio/gdesktopappinfo.h>
 
 #include <libxfdashboard/stage.h>
@@ -57,7 +60,11 @@ GType xfdashboard_pointer_array_get_type(void)
 
 	if(g_once_init_enter(&type__volatile))
 	{
+#ifdef XFCONF_LEGACY
+		type=dbus_g_type_get_collection("GPtrArray", G_TYPE_VALUE);
+#else
 		type=G_TYPE_PTR_ARRAY;
+#endif
 		g_once_init_leave(&type__volatile, type);
 	}
 


### PR DESCRIPTION
It's merge of my 2 opened bugs:
- https://bugzilla.xfce.org/show_bug.cgi?id=13766
- https://bugzilla.xfce.org/show_bug.cgi?id=13824

It adds additional check for Clutter's backend (GDK), not yet available on FreeBSD and NetBSD.

It provides support of xfconf > 4.13 (and also < 4.13, with support of dbus-glib).