### PR TITLE
Allow clicking buttons on a touch screen

### DIFF
--- a/libxfdashboard/button.c
+++ b/libxfdashboard/button.c
@@ -85,7 +85,7 @@ static void _xfdashboard_button_clicked(XfdashboardClickAction *inAction,
 	/* Only emit any of these signals if click was perform with left button 
 	 * or is a short touchscreen touch event.
 	 */
-	if(xfdashboard_click_action_is_left_button_or_touch(inAction))
+	if(xfdashboard_click_action_is_left_button_or_tap(inAction))
 	{
 		/* Emit 'clicked' signal */
 		g_signal_emit(self, XfdashboardButtonSignals[SIGNAL_CLICKED], 0);

--- a/libxfdashboard/button.c
+++ b/libxfdashboard/button.c
@@ -82,8 +82,11 @@ static void _xfdashboard_button_clicked(XfdashboardClickAction *inAction,
 	g_return_if_fail(XFDASHBOARD_IS_CLICK_ACTION(inAction));
 	g_return_if_fail(XFDASHBOARD_IS_BUTTON(self));
 
-	/* Only emit signal if click was perform with left button */
-	if(xfdashboard_click_action_get_button(inAction)==XFDASHBOARD_CLICK_ACTION_LEFT_BUTTON)
+	/* Only emit any of these signals if click was perform with left button 
+	 * or is a short touchscreen touch event.
+	 */
+	if(xfdashboard_click_action_get_button(inAction)!=XFDASHBOARD_CLICK_ACTION_LEFT_BUTTON &&
+			xfdashboard_click_action_get_button(inAction)!=0) return;
 	{
 		/* Emit 'clicked' signal */
 		g_signal_emit(self, XfdashboardButtonSignals[SIGNAL_CLICKED], 0);

--- a/libxfdashboard/button.c
+++ b/libxfdashboard/button.c
@@ -85,8 +85,7 @@ static void _xfdashboard_button_clicked(XfdashboardClickAction *inAction,
 	/* Only emit any of these signals if click was perform with left button 
 	 * or is a short touchscreen touch event.
 	 */
-	if(xfdashboard_click_action_get_button(inAction)!=XFDASHBOARD_CLICK_ACTION_LEFT_BUTTON &&
-			xfdashboard_click_action_get_button(inAction)!=0) return;
+    if(xfdashboard_click_action_is_left_button_or_touch(inAction))
 	{
 		/* Emit 'clicked' signal */
 		g_signal_emit(self, XfdashboardButtonSignals[SIGNAL_CLICKED], 0);

--- a/libxfdashboard/button.c
+++ b/libxfdashboard/button.c
@@ -85,7 +85,7 @@ static void _xfdashboard_button_clicked(XfdashboardClickAction *inAction,
 	/* Only emit any of these signals if click was perform with left button 
 	 * or is a short touchscreen touch event.
 	 */
-    if(xfdashboard_click_action_is_left_button_or_touch(inAction))
+	if(xfdashboard_click_action_is_left_button_or_touch(inAction))
 	{
 		/* Emit 'clicked' signal */
 		g_signal_emit(self, XfdashboardButtonSignals[SIGNAL_CLICKED], 0);

--- a/libxfdashboard/click-action.c
+++ b/libxfdashboard/click-action.c
@@ -478,7 +478,7 @@ static gboolean _xfdashboard_click_action_on_event(XfdashboardClickAction *self,
 			}
 
 			/* Remember event data */
-			priv->pressButton=hasButton ? clutter_event_get_button(inEvent) : 0;
+			priv->pressButton=hasButton ? clutter_event_get_button(inEvent) : 1;
 			priv->pressDeviceID=clutter_event_get_device_id(inEvent);
 			priv->pressSequence=clutter_event_get_event_sequence(inEvent);
 			priv->modifierState=clutter_event_get_state(inEvent);

--- a/libxfdashboard/click-action.c
+++ b/libxfdashboard/click-action.c
@@ -887,3 +887,24 @@ void xfdashboard_click_action_release(XfdashboardClickAction *self)
 	_xfdashboard_click_action_set_held(self, FALSE);
 	_xfdashboard_click_action_set_pressed(self, FALSE);
 }
+
+/**
+ * xfdashboard_click_action_is_left_button_or_touch
+ * @self: A #XfdashboardClickAction
+ *
+ * Checks if the specified click action is either a left button press or a single touch 'tap'
+ */
+gboolean xfdashboard_click_action_is_left_button_or_touch(XfdashboardClickAction *self)
+{
+	XfdashboardClickActionPrivate *priv;
+	g_return_val_if_fail(XFDASHBOARD_IS_CLICK_ACTION(self), FALSE);
+
+	priv=self->priv;
+
+	if(priv->pressButton==0 || priv->pressButton==XFDASHBOARD_CLICK_ACTION_LEFT_BUTTON)
+	{
+		return(TRUE);
+	}
+
+	return(FALSE);
+}

--- a/libxfdashboard/click-action.c
+++ b/libxfdashboard/click-action.c
@@ -478,7 +478,7 @@ static gboolean _xfdashboard_click_action_on_event(XfdashboardClickAction *self,
 			}
 
 			/* Remember event data */
-			priv->pressButton=hasButton ? clutter_event_get_button(inEvent) : 1;
+			priv->pressButton=hasButton ? clutter_event_get_button(inEvent) : 0;
 			priv->pressDeviceID=clutter_event_get_device_id(inEvent);
 			priv->pressSequence=clutter_event_get_event_sequence(inEvent);
 			priv->modifierState=clutter_event_get_state(inEvent);

--- a/libxfdashboard/click-action.c
+++ b/libxfdashboard/click-action.c
@@ -893,8 +893,11 @@ void xfdashboard_click_action_release(XfdashboardClickAction *self)
  * @self: A #XfdashboardClickAction
  *
  * Checks if the specified click action is either a left button press or a single touch 'tap'
+ *
+ * Return value: Returns %TRUE if the click action event is a left button press or a single 
+ * touch tap, otherwise %FALSE
  */
-gboolean xfdashboard_click_action_is_left_button_or_touch(XfdashboardClickAction *self)
+gboolean xfdashboard_click_action_is_left_button_or_tap(XfdashboardClickAction *self)
 {
 	XfdashboardClickActionPrivate *priv;
 	g_return_val_if_fail(XFDASHBOARD_IS_CLICK_ACTION(self), FALSE);

--- a/libxfdashboard/click-action.h
+++ b/libxfdashboard/click-action.h
@@ -128,6 +128,8 @@ void xfdashboard_click_action_get_coords(XfdashboardClickAction *self, gfloat *o
 
 void xfdashboard_click_action_release(XfdashboardClickAction *self);
 
+gboolean xfdashboard_click_action_is_left_button_or_touch(XfdashboardClickAction *self);
+
 G_END_DECLS
 
 #endif	/* __LIBXFDASHBOARD_CLICK_ACTION__ */

--- a/libxfdashboard/click-action.h
+++ b/libxfdashboard/click-action.h
@@ -128,7 +128,7 @@ void xfdashboard_click_action_get_coords(XfdashboardClickAction *self, gfloat *o
 
 void xfdashboard_click_action_release(XfdashboardClickAction *self);
 
-gboolean xfdashboard_click_action_is_left_button_or_touch(XfdashboardClickAction *self);
+gboolean xfdashboard_click_action_is_left_button_or_tap(XfdashboardClickAction *self);
 
 G_END_DECLS
 

--- a/libxfdashboard/live-window.c
+++ b/libxfdashboard/live-window.c
@@ -360,8 +360,7 @@ static void _xfdashboard_live_window_on_clicked(XfdashboardLiveWindow *self,
 	/* Only emit any of these signals if click was perform with left button 
 	 * or is a short touchscreen touch event.
 	 */
-	if(xfdashboard_click_action_get_button(action)!=XFDASHBOARD_CLICK_ACTION_LEFT_BUTTON &&
-			xfdashboard_click_action_get_button(action)!=0)
+    if(!xfdashboard_click_action_is_left_button_or_touch(action))
 	{
 		return;
 	}

--- a/libxfdashboard/live-window.c
+++ b/libxfdashboard/live-window.c
@@ -360,7 +360,7 @@ static void _xfdashboard_live_window_on_clicked(XfdashboardLiveWindow *self,
 	/* Only emit any of these signals if click was perform with left button 
 	 * or is a short touchscreen touch event.
 	 */
-    if(!xfdashboard_click_action_is_left_button_or_touch(action))
+	if(!xfdashboard_click_action_is_left_button_or_touch(action))
 	{
 		return;
 	}

--- a/libxfdashboard/live-window.c
+++ b/libxfdashboard/live-window.c
@@ -360,7 +360,7 @@ static void _xfdashboard_live_window_on_clicked(XfdashboardLiveWindow *self,
 	/* Only emit any of these signals if click was perform with left button 
 	 * or is a short touchscreen touch event.
 	 */
-	if(!xfdashboard_click_action_is_left_button_or_touch(action))
+	if(!xfdashboard_click_action_is_left_button_or_tap(action))
 	{
 		return;
 	}

--- a/libxfdashboard/live-window.c
+++ b/libxfdashboard/live-window.c
@@ -357,8 +357,14 @@ static void _xfdashboard_live_window_on_clicked(XfdashboardLiveWindow *self,
 	priv=self->priv;
 	action=XFDASHBOARD_CLICK_ACTION(inUserData);
 
-	/* Only emit any of these signals if click was perform with left button */
-	if(xfdashboard_click_action_get_button(action)!=XFDASHBOARD_CLICK_ACTION_LEFT_BUTTON) return;
+	/* Only emit any of these signals if click was perform with left button 
+	 * or is a short touchscreen touch event.
+	 */
+	if(xfdashboard_click_action_get_button(action)!=XFDASHBOARD_CLICK_ACTION_LEFT_BUTTON &&
+			xfdashboard_click_action_get_button(action)!=0)
+	{
+		return;
+	}
 
 	/* Check if click happened in "close button" */
 	if(clutter_actor_is_visible(priv->actorClose))

--- a/libxfdashboard/live-workspace.c
+++ b/libxfdashboard/live-workspace.c
@@ -348,7 +348,7 @@ static void _xfdashboard_live_workspace_on_clicked(XfdashboardLiveWorkspace *sel
 	/* Only emit any of these signals if click was perform with left button 
 	 * or is a short touchscreen touch event.
 	 */
-    if(xfdashboard_click_action_is_left_button_or_touch(action))
+	if(xfdashboard_click_action_is_left_button_or_touch(action))
 	{
 		/* Emit "clicked" signal */
 		g_signal_emit(self, XfdashboardLiveWorkspaceSignals[SIGNAL_CLICKED], 0);

--- a/libxfdashboard/live-workspace.c
+++ b/libxfdashboard/live-workspace.c
@@ -348,8 +348,7 @@ static void _xfdashboard_live_workspace_on_clicked(XfdashboardLiveWorkspace *sel
 	/* Only emit any of these signals if click was perform with left button 
 	 * or is a short touchscreen touch event.
 	 */
-	if(xfdashboard_click_action_get_button(action)!=XFDASHBOARD_CLICK_ACTION_LEFT_BUTTON &&
-			xfdashboard_click_action_get_button(action)!=0)
+    if(xfdashboard_click_action_is_left_button_or_touch(action))
 	{
 		/* Emit "clicked" signal */
 		g_signal_emit(self, XfdashboardLiveWorkspaceSignals[SIGNAL_CLICKED], 0);

--- a/libxfdashboard/live-workspace.c
+++ b/libxfdashboard/live-workspace.c
@@ -348,7 +348,7 @@ static void _xfdashboard_live_workspace_on_clicked(XfdashboardLiveWorkspace *sel
 	/* Only emit any of these signals if click was perform with left button 
 	 * or is a short touchscreen touch event.
 	 */
-	if(xfdashboard_click_action_is_left_button_or_touch(action))
+	if(xfdashboard_click_action_is_left_button_or_tap(action))
 	{
 		/* Emit "clicked" signal */
 		g_signal_emit(self, XfdashboardLiveWorkspaceSignals[SIGNAL_CLICKED], 0);

--- a/libxfdashboard/live-workspace.c
+++ b/libxfdashboard/live-workspace.c
@@ -345,8 +345,11 @@ static void _xfdashboard_live_workspace_on_clicked(XfdashboardLiveWorkspace *sel
 
 	action=XFDASHBOARD_CLICK_ACTION(inUserData);
 
-	/* Only emit signal if click was perform with left button */
-	if(xfdashboard_click_action_get_button(action)==XFDASHBOARD_CLICK_ACTION_LEFT_BUTTON)
+	/* Only emit any of these signals if click was perform with left button 
+	 * or is a short touchscreen touch event.
+	 */
+	if(xfdashboard_click_action_get_button(action)!=XFDASHBOARD_CLICK_ACTION_LEFT_BUTTON &&
+			xfdashboard_click_action_get_button(action)!=0)
 	{
 		/* Emit "clicked" signal */
 		g_signal_emit(self, XfdashboardLiveWorkspaceSignals[SIGNAL_CLICKED], 0);

--- a/libxfdashboard/popup-menu-item-button.c
+++ b/libxfdashboard/popup-menu-item-button.c
@@ -66,8 +66,7 @@ static void _xfdashboard_popup_menu_item_button_clicked(XfdashboardClickAction *
 	/* Only emit any of these signals if click was perform with left button 
 	 * or is a short touchscreen touch event.
 	 */
-	if(xfdashboard_click_action_get_button(inAction)!=XFDASHBOARD_CLICK_ACTION_LEFT_BUTTON &&
-			xfdashboard_click_action_get_button(inAction)!=0) return;
+    if(xfdashboard_click_action_is_left_button_or_touch(inAction))
 	{
 		xfdashboard_popup_menu_item_activate(XFDASHBOARD_POPUP_MENU_ITEM(self));
 	}

--- a/libxfdashboard/popup-menu-item-button.c
+++ b/libxfdashboard/popup-menu-item-button.c
@@ -66,7 +66,7 @@ static void _xfdashboard_popup_menu_item_button_clicked(XfdashboardClickAction *
 	/* Only emit any of these signals if click was perform with left button 
 	 * or is a short touchscreen touch event.
 	 */
-    if(xfdashboard_click_action_is_left_button_or_touch(inAction))
+	if(xfdashboard_click_action_is_left_button_or_touch(inAction))
 	{
 		xfdashboard_popup_menu_item_activate(XFDASHBOARD_POPUP_MENU_ITEM(self));
 	}

--- a/libxfdashboard/popup-menu-item-button.c
+++ b/libxfdashboard/popup-menu-item-button.c
@@ -66,7 +66,7 @@ static void _xfdashboard_popup_menu_item_button_clicked(XfdashboardClickAction *
 	/* Only emit any of these signals if click was perform with left button 
 	 * or is a short touchscreen touch event.
 	 */
-	if(xfdashboard_click_action_is_left_button_or_touch(inAction))
+	if(xfdashboard_click_action_is_left_button_or_tap(inAction))
 	{
 		xfdashboard_popup_menu_item_activate(XFDASHBOARD_POPUP_MENU_ITEM(self));
 	}

--- a/libxfdashboard/popup-menu-item-button.c
+++ b/libxfdashboard/popup-menu-item-button.c
@@ -63,8 +63,11 @@ static void _xfdashboard_popup_menu_item_button_clicked(XfdashboardClickAction *
 	g_return_if_fail(XFDASHBOARD_IS_CLICK_ACTION(inAction));
 	g_return_if_fail(XFDASHBOARD_IS_POPUP_MENU_ITEM_BUTTON(self));
 
-	/* Only activate item if click was perform with left button */
-	if(xfdashboard_click_action_get_button(inAction)==XFDASHBOARD_CLICK_ACTION_LEFT_BUTTON)
+	/* Only emit any of these signals if click was perform with left button 
+	 * or is a short touchscreen touch event.
+	 */
+	if(xfdashboard_click_action_get_button(inAction)!=XFDASHBOARD_CLICK_ACTION_LEFT_BUTTON &&
+			xfdashboard_click_action_get_button(inAction)!=0) return;
 	{
 		xfdashboard_popup_menu_item_activate(XFDASHBOARD_POPUP_MENU_ITEM(self));
 	}

--- a/libxfdashboard/quicklaunch.c
+++ b/libxfdashboard/quicklaunch.c
@@ -671,8 +671,11 @@ static void _xfdashboard_quicklaunch_on_favourite_popup_menu(XfdashboardQuicklau
 	appButton=XFDASHBOARD_APPLICATION_BUTTON(inActor);
 	action=XFDASHBOARD_CLICK_ACTION(inUserData);
 
-	/* Check if right button was used when the application button was clicked */
-	if(xfdashboard_click_action_get_button(action)==XFDASHBOARD_CLICK_ACTION_RIGHT_BUTTON)
+	/* Only emit any of these signals if click was perform with left button 
+	 * or is a short touchscreen touch event.
+	 */
+	if(xfdashboard_click_action_get_button(action)!=XFDASHBOARD_CLICK_ACTION_LEFT_BUTTON &&
+			xfdashboard_click_action_get_button(action)!=0) return;
 	{
 		ClutterActor							*popup;
 		ClutterActor							*menuItem;

--- a/libxfdashboard/quicklaunch.c
+++ b/libxfdashboard/quicklaunch.c
@@ -674,8 +674,7 @@ static void _xfdashboard_quicklaunch_on_favourite_popup_menu(XfdashboardQuicklau
 	/* Only emit any of these signals if click was perform with left button 
 	 * or is a short touchscreen touch event.
 	 */
-	if(xfdashboard_click_action_get_button(action)!=XFDASHBOARD_CLICK_ACTION_LEFT_BUTTON &&
-			xfdashboard_click_action_get_button(action)!=0) return;
+    if(xfdashboard_click_action_is_left_button_or_touch(action))
 	{
 		ClutterActor							*popup;
 		ClutterActor							*menuItem;

--- a/libxfdashboard/quicklaunch.c
+++ b/libxfdashboard/quicklaunch.c
@@ -674,7 +674,7 @@ static void _xfdashboard_quicklaunch_on_favourite_popup_menu(XfdashboardQuicklau
 	/* Only emit any of these signals if click was perform with left button 
 	 * or is a short touchscreen touch event.
 	 */
-	if(xfdashboard_click_action_is_left_button_or_touch(action))
+	if(xfdashboard_click_action_is_left_button_or_tap(action))
 	{
 		ClutterActor							*popup;
 		ClutterActor							*menuItem;

--- a/libxfdashboard/quicklaunch.c
+++ b/libxfdashboard/quicklaunch.c
@@ -674,7 +674,7 @@ static void _xfdashboard_quicklaunch_on_favourite_popup_menu(XfdashboardQuicklau
 	/* Only emit any of these signals if click was perform with left button 
 	 * or is a short touchscreen touch event.
 	 */
-    if(xfdashboard_click_action_is_left_button_or_touch(action))
+	if(xfdashboard_click_action_is_left_button_or_touch(action))
 	{
 		ClutterActor							*popup;
 		ClutterActor							*menuItem;

--- a/libxfdashboard/search-result-container.c
+++ b/libxfdashboard/search-result-container.c
@@ -396,7 +396,7 @@ static void _xfdashboard_search_result_container_on_result_item_actor_clicked(Xf
 	/* Only emit any of these signals if click was perform with left button 
 	 * or is a short touchscreen touch event.
 	 */
-    if(xfdashboard_click_action_is_left_button_or_touch(inAction))
+	if(xfdashboard_click_action_is_left_button_or_touch(inAction))
 	{
 		/* Activate result item by actor clicked */
 		_xfdashboard_search_result_container_activate_result_item_by_actor(self, inActor);

--- a/libxfdashboard/search-result-container.c
+++ b/libxfdashboard/search-result-container.c
@@ -393,8 +393,11 @@ static void _xfdashboard_search_result_container_on_result_item_actor_clicked(Xf
 
 	self=XFDASHBOARD_SEARCH_RESULT_CONTAINER(inUserData);
 
-	/* Only emit signal if click was perform with left button */
-	if(xfdashboard_click_action_get_button(inAction)==XFDASHBOARD_CLICK_ACTION_LEFT_BUTTON)
+	/* Only emit any of these signals if click was perform with left button 
+	 * or is a short touchscreen touch event.
+	 */
+	if(xfdashboard_click_action_get_button(inAction)!=XFDASHBOARD_CLICK_ACTION_LEFT_BUTTON &&
+			xfdashboard_click_action_get_button(inAction)!=0) return;
 	{
 		/* Activate result item by actor clicked */
 		_xfdashboard_search_result_container_activate_result_item_by_actor(self, inActor);

--- a/libxfdashboard/search-result-container.c
+++ b/libxfdashboard/search-result-container.c
@@ -396,8 +396,7 @@ static void _xfdashboard_search_result_container_on_result_item_actor_clicked(Xf
 	/* Only emit any of these signals if click was perform with left button 
 	 * or is a short touchscreen touch event.
 	 */
-	if(xfdashboard_click_action_get_button(inAction)!=XFDASHBOARD_CLICK_ACTION_LEFT_BUTTON &&
-			xfdashboard_click_action_get_button(inAction)!=0) return;
+    if(xfdashboard_click_action_is_left_button_or_touch(inAction))
 	{
 		/* Activate result item by actor clicked */
 		_xfdashboard_search_result_container_activate_result_item_by_actor(self, inActor);

--- a/libxfdashboard/search-result-container.c
+++ b/libxfdashboard/search-result-container.c
@@ -396,7 +396,7 @@ static void _xfdashboard_search_result_container_on_result_item_actor_clicked(Xf
 	/* Only emit any of these signals if click was perform with left button 
 	 * or is a short touchscreen touch event.
 	 */
-	if(xfdashboard_click_action_is_left_button_or_touch(inAction))
+	if(xfdashboard_click_action_is_left_button_or_tap(inAction))
 	{
 		/* Activate result item by actor clicked */
 		_xfdashboard_search_result_container_activate_result_item_by_actor(self, inActor);


### PR DESCRIPTION
My main desired usecase of xfdashboard is as an app launcher and window switcher when my 2-in-1 is in tablet mode. However, tocuhes didn't seem to register as clicks until I made this very simple change.

I assume that there is some constant that would be better to use instead of `1` but I haven't looked into it.

Scrolling in menus also doesn't work on the touch screen which may or may not be related to this. Other than that, everything seems to work.